### PR TITLE
fix: Can't Verify Saleforce Connection (#12)

### DIFF
--- a/src/main/java/io/syndesis/verifier/impl/BaseVerifier.java
+++ b/src/main/java/io/syndesis/verifier/impl/BaseVerifier.java
@@ -28,7 +28,7 @@ public abstract class BaseVerifier implements Verifier {
         camel = new DefaultCamelContext();
         camel.start();
 
-        Component verifierComponent = camel.getComponent(getConnectorAction());
+        Component verifierComponent = camel.getComponent(getConnectorAction(), true, false);
         if (verifierComponent instanceof VerifiableComponent) {
             VerifiableComponent vc = (VerifiableComponent) verifierComponent;
             verifier = vc.getVerifier();

--- a/src/main/java/io/syndesis/verifier/impl/SalesforceVerifier.java
+++ b/src/main/java/io/syndesis/verifier/impl/SalesforceVerifier.java
@@ -1,7 +1,5 @@
 package io.syndesis.verifier.impl;
 
-import java.util.Map;
-
 import org.springframework.stereotype.Component;
 
 /**
@@ -10,12 +8,8 @@ import org.springframework.stereotype.Component;
  */
 @Component("salesforce")
 public class SalesforceVerifier extends BaseVerifier {
-    protected String getConnectorAction() {
-        return "salesforce-upsert-contact";
-    }
-
     @Override
-    protected void customize(Map<String, Object> params) {
-        params.put("operationName", "UPSERT_SOBJECT");
+    protected String getConnectorAction() {
+        return "salesforce";
     }
 }


### PR DESCRIPTION
Removes the `operationName` added by `SalesforceVerifier` to the parameters map. The `operationName` is not required and I think it should not be added.

Also changes the connector name from `salesforce-upsert-contact` to just `salesforce`.

Also creates Camel components without starting them as it is not needed for verifying the component that the component is started.

Assumes:
 - component does not need to be started for verification to succeed
 - can use _mother_ component (i.e. salesforce) instead of connector (
   i.e _salesforce-upsert-contact_)

Does not:
 - make the same change for other verifiers (HTTP, Twitter)