### PR TITLE
chore(metadata): Support for dynamic action properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-    <camel.version>2.19.0</camel.version>
+    <camel.version>2.20.0-SNAPSHOT</camel.version>
     <swagger.version>1.5.12</swagger.version>
     <resteasy-spring-boot-starter.version>2.3.0-RELEASE</resteasy-spring-boot-starter.version>
     <jackson.version>2.8.7</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,20 @@
     </repository>
   </distributionManagement>
 
+  <repositories>
+    <repository>
+      <id>apache.snapshots</id>
+      <name>Apache Development Snapshot Repository</name>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -74,14 +74,14 @@
 
   <repositories>
     <repository>
-      <id>apache.snapshots</id>
-      <name>Apache Development Snapshot Repository</name>
-      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+      <id>jboss-ea</id>
+      <name>JBoss Early-access repository</name>
+      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
       <releases>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </releases>
       <snapshots>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
       </snapshots>
     </repository>
   </repositories>
@@ -93,7 +93,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-    <camel.version>2.20.0-SNAPSHOT</camel.version>
+    <camel.version>2.20.0.fuse-000091</camel.version>
     <swagger.version>1.5.12</swagger.version>
     <resteasy-spring-boot-starter.version>2.3.0-RELEASE</resteasy-spring-boot-starter.version>
     <jackson.version>2.8.7</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.el</artifactId>
       <scope>test</scope>

--- a/src/main/java/io/syndesis/verifier/v1/ActionPropertiesEndpoint.java
+++ b/src/main/java/io/syndesis/verifier/v1/ActionPropertiesEndpoint.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.verifier.v1;
+
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.syndesis.verifier.v1.metadata.MetadataAdapter;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.MetaDataExtension;
+import org.apache.camel.component.extension.MetaDataExtension.MetaData;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.springframework.stereotype.Component;
+
+@Component
+@Path("/action/properties")
+public class ActionPropertiesEndpoint {
+
+    private final Map<String, MetadataAdapter> adapters;
+
+    public ActionPropertiesEndpoint(final Map<String, MetadataAdapter> adapters) {
+        this.adapters = adapters;
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/{id}")
+    public Object properties(@PathParam("id") final String connectorId, final Map<String, Object> properties)
+        throws Exception {
+        final MetadataAdapter adapter = adapters.get(connectorId + "-adapter");
+
+        if (adapter == null) {
+            throw null;
+        }
+
+        final CamelContext camel = new DefaultCamelContext();
+        camel.start();
+
+        try {
+            final MetaData metaData = fetchMetadata(camel, connectorId, properties);
+
+            return adapter.apply(properties, metaData);
+        } finally {
+            camel.stop();
+        }
+    }
+
+    static MetaData fetchMetadata(final CamelContext camel, final String connectorId,
+        final Map<String, Object> properties) {
+        final MetaDataExtension metadataExtension = camel.getComponent(connectorId, true, false)
+            .getExtension(MetaDataExtension.class).orElseThrow(
+                () -> new IllegalArgumentException("No Metadata extension present for connector: " + connectorId));
+
+        return metadataExtension.meta(properties)
+            .orElseThrow(() -> new IllegalArgumentException("No Metadata returned by the metadata extension"));
+    }
+}

--- a/src/main/java/io/syndesis/verifier/v1/ActionPropertiesEndpoint.java
+++ b/src/main/java/io/syndesis/verifier/v1/ActionPropertiesEndpoint.java
@@ -54,7 +54,7 @@ public class ActionPropertiesEndpoint {
             throw null;
         }
 
-        final CamelContext camel = new DefaultCamelContext();
+        final CamelContext camel = camelContext();
         camel.start();
 
         try {
@@ -64,6 +64,10 @@ public class ActionPropertiesEndpoint {
         } finally {
             camel.stop();
         }
+    }
+
+    protected DefaultCamelContext camelContext() {
+        return new DefaultCamelContext();
     }
 
     static MetaData fetchMetadata(final CamelContext camel, final String connectorId,

--- a/src/main/java/io/syndesis/verifier/v1/metadata/MetadataAdapter.java
+++ b/src/main/java/io/syndesis/verifier/v1/metadata/MetadataAdapter.java
@@ -4,8 +4,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+import org.apache.camel.component.extension.MetaDataExtension;
 import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 
+/**
+ * Converting metadata to applicable properties is specific to each connector,
+ * this adapter converts Camel {@link MetaDataExtension.MetaData} to a Map keyed
+ * by action property name with a list of {@link PropertyPair} values that are
+ * applicable to for that property. {@link #apply(Map, MetaData)} method will
+ * receive all properties that client specified and the retrieved
+ * {@link MetaDataExtension.MetaData} from the appropriate Camel
+ * {@link MetaDataExtension}.
+ */
 @FunctionalInterface
 public interface MetadataAdapter extends BiFunction<Map<String, Object>, MetaData, Map<String, List<PropertyPair>>> {
     // inherits apply(MetaData) from Function

--- a/src/main/java/io/syndesis/verifier/v1/metadata/MetadataAdapter.java
+++ b/src/main/java/io/syndesis/verifier/v1/metadata/MetadataAdapter.java
@@ -1,0 +1,12 @@
+package io.syndesis.verifier.v1.metadata;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.apache.camel.component.extension.MetaDataExtension.MetaData;
+
+@FunctionalInterface
+public interface MetadataAdapter extends BiFunction<Map<String, Object>, MetaData, Map<String, List<PropertyPair>>> {
+    // inherits apply(MetaData) from Function
+}

--- a/src/main/java/io/syndesis/verifier/v1/metadata/PropertyPair.java
+++ b/src/main/java/io/syndesis/verifier/v1/metadata/PropertyPair.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.verifier.v1.metadata;
+
+import java.util.Objects;
+
+public final class PropertyPair {
+
+    private final String displayValue;
+
+    private final String value;
+
+    public PropertyPair(final String value, final String displayValue) {
+        this.value = value;
+        this.displayValue = displayValue;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (!(obj instanceof PropertyPair)) {
+            return false;
+        }
+
+        final PropertyPair other = (PropertyPair) obj;
+
+        return Objects.equals(other.displayValue, displayValue) && Objects.equals(other.value, value);
+    }
+
+    public String getDisplayValue() {
+        return displayValue;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Objects.hashCode(value) + 31 * Objects.hashCode(displayValue);
+    }
+}

--- a/src/main/java/io/syndesis/verifier/v1/metadata/PropertyPair.java
+++ b/src/main/java/io/syndesis/verifier/v1/metadata/PropertyPair.java
@@ -55,4 +55,9 @@ public final class PropertyPair {
     public int hashCode() {
         return 31 * Objects.hashCode(value) + 31 * Objects.hashCode(displayValue);
     }
+
+    @Override
+    public String toString() {
+        return value + "=" + displayValue;
+    }
 }

--- a/src/main/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapter.java
+++ b/src/main/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapter.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.verifier.v1.metadata;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.SimpleTypeSchema;
+
+import org.apache.camel.component.extension.MetaDataExtension.MetaData;
+import org.springframework.stereotype.Component;
+
+@Component("salesforce-adapter")
+public final class SalesforceMetadataAdapter implements MetadataAdapter {
+
+    private static final String UNIQUE_PROPERTY = "sObjectIdName";
+
+    @Override
+    public Map<String, List<PropertyPair>> apply(final Map<String, Object> properties, final MetaData metaData) {
+        final String scope = (String) metaData.getAttribute("scope");
+
+        if ("object".equals(scope)) {
+            return adaptForObjectRequest(properties, metaData);
+        } else if ("object_types".equals(scope)) {
+            return adaptForObjectTypeRequest(properties, metaData);
+        }
+
+        throw new IllegalStateException(
+            "Unknown or missing `scope` attribute in Salesforce MetaData, scope is: " + scope);
+    }
+
+    static Map<String, List<PropertyPair>> adaptForObjectRequest(final Map<String, Object> properties,
+        final MetaData metaData) {
+        final Map<String, List<PropertyPair>> ret = new HashMap<>();
+
+        final ObjectSchema schema = objectSchemaFrom(metaData.getPayload(ObjectSchema.class));
+        if (properties.containsKey(UNIQUE_PROPERTY)) {
+            final List<PropertyPair> uniquePropertyPairs = schema.getProperties().entrySet().stream()
+                .filter(e -> isIdLookup(e.getValue()))
+                .map(SalesforceMetadataAdapter::createFieldPairPropertyFromSchemaEntry).collect(Collectors.toList());
+
+            ret.put(UNIQUE_PROPERTY, uniquePropertyPairs);
+        }
+
+        return ret;
+    }
+
+    static Map<String, List<PropertyPair>> adaptForObjectTypeRequest(final Map<String, Object> properties,
+        final MetaData metaData) {
+        final JsonNode payload = metaData.getPayload(JsonNode.class);
+
+        final List<PropertyPair> objects = StreamSupport.stream(payload.spliterator(), false)
+            .map(SalesforceMetadataAdapter::createObjectPairPropertyFromNode).collect(Collectors.toList());
+
+        return Collections.singletonMap("sObjectName", objects);
+    }
+
+    static PropertyPair createFieldPairPropertyFromSchemaEntry(final Entry<String, JsonSchema> e) {
+        return new PropertyPair(e.getKey(), ((SimpleTypeSchema) e.getValue()).getTitle());
+    }
+
+    static PropertyPair createObjectPairPropertyFromNode(final JsonNode node) {
+        final String value = node.get("name").asText();
+        final String displayValue = node.get("label").asText();
+
+        return new PropertyPair(value, displayValue);
+    }
+
+    static boolean isIdLookup(final JsonSchema property) {
+        final String description = property.getDescription();
+
+        if (description == null) {
+            return false;
+        }
+
+        return description.contains("idLookup");
+    }
+
+    static ObjectSchema objectSchemaFrom(final ObjectSchema schema) {
+        if (schema.getOneOf().isEmpty()) {
+            return schema;
+        }
+
+        return (ObjectSchema) schema.getOneOf().stream().filter(ObjectSchema.class::isInstance)
+            .filter(s -> !((ObjectSchema) s).getId().contains(":QueryRecords")).findFirst()
+            .orElseThrow(() -> new IllegalStateException(
+                "The resulting schema does not contain an non query records object schema in `oneOf`"));
+    }
+
+}

--- a/src/test/java/io/syndesis/verifier/v1/ActionPropertiesEndpointTest.java
+++ b/src/test/java/io/syndesis/verifier/v1/ActionPropertiesEndpointTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.verifier.v1;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.syndesis.verifier.v1.metadata.MetadataAdapter;
+import io.syndesis.verifier.v1.metadata.PropertyPair;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.component.extension.MetaDataExtension;
+import org.apache.camel.component.extension.MetaDataExtension.MetaData;
+import org.apache.camel.component.extension.metadata.MetaDataBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.DefaultComponent;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ActionPropertiesEndpointTest {
+
+    private static final Map<String, String> PAYLOAD = Collections.singletonMap("this", "is playload");
+
+    private static final Map<String, List<PropertyPair>> PROPERTIES = Collections.singletonMap("property",
+        Arrays.asList(new PropertyPair("value1", "First Value"), new PropertyPair("value2", "Second Value")));
+    private final ActionPropertiesEndpoint endpoint = new ActionPropertiesEndpoint(
+        Collections.singletonMap("petstore-adapter", new PetstoreAdapter())) {
+        @Override
+        protected DefaultCamelContext camelContext() {
+            final DefaultCamelContext camelContext = new DefaultCamelContext();
+            camelContext.addComponent("petstore", new PetstoreComponent());
+
+            return camelContext;
+        }
+    };
+
+    public static class PetstoreAdapter implements MetadataAdapter {
+
+        @Override
+        public Map<String, List<PropertyPair>> apply(final Map<String, Object> properties, final MetaData metadata) {
+            @SuppressWarnings("unchecked")
+            final Map<String, String> payload = metadata.getPayload(Map.class);
+
+            assertThat(payload).isSameAs(PAYLOAD);
+
+            return PROPERTIES;
+        }
+
+    }
+
+    private static class PetstoreComponent extends DefaultComponent {
+
+        public PetstoreComponent() {
+            registerExtension((MetaDataExtension) parameters -> Optional
+                .of(MetaDataBuilder.on(getCamelContext()).withPayload(PAYLOAD).build()));
+        }
+
+        @Override
+        protected Endpoint createEndpoint(final String uri, final String remaining,
+            final Map<String, Object> parameters) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    public void shouldProvideActionPropertiesBasedOnMetadata() throws Exception {
+        final Object properties = endpoint.properties("petstore", Collections.emptyMap());
+
+        assertThat(properties).isSameAs(PROPERTIES);
+    }
+}

--- a/src/test/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapterTest.java
+++ b/src/test/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapterTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.verifier.v1.metadata;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.NumberSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.metadata.MetaDataBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SalesforceMetadataAdapterTest {
+
+    private static final CamelContext CONTEXT = new DefaultCamelContext();
+
+    private static final Map<String, Object> NOT_USED = null;
+
+    private final SalesforceMetadataAdapter adapter = new SalesforceMetadataAdapter();
+
+    @Test
+    public void shouldAdaptObjectMetadata() throws IOException {
+        final Map<String, JsonSchema> objectProperties = new HashMap<>();
+        objectProperties.put("simpleProperty", new StringSchema());
+        objectProperties.put("anotherProperty", new NumberSchema());
+
+        final StringSchema uniqueProperty1 = new StringSchema();
+        uniqueProperty1.setDescription("idLookup,autoNumber");
+        uniqueProperty1.setTitle("Unique property 1");
+
+        final StringSchema uniqueProperty2 = new StringSchema();
+        uniqueProperty2.setDescription("calculated,idLookup");
+        uniqueProperty2.setTitle("Unique property 2");
+
+        objectProperties.put("uniqueProperty1", uniqueProperty1);
+        objectProperties.put("uniqueProperty2", uniqueProperty2);
+
+        final ObjectSchema objectSchema = new ObjectSchema();
+        objectSchema.setId("urn:jsonschema:org:apache:camel:component:salesforce:dto:SimpleObject");
+        objectSchema.setProperties(objectProperties);
+
+        final ObjectSchema payload = new ObjectSchema();
+        payload.setOneOf(Collections.singleton(objectSchema));
+
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("sObjectName", "SimpleObject");
+        properties.put("sObjectIdName", null);
+
+        final Map<String, List<PropertyPair>> adapted = adapter.apply(properties,
+            MetaDataBuilder.on(CONTEXT).withAttribute("scope", "object").withPayload(payload).build());
+
+        assertThat(adapted).containsKey("sObjectIdName");
+
+        final List<PropertyPair> values = adapted.get("sObjectIdName");
+
+        assertThat(values).containsOnly(new PropertyPair("uniqueProperty1", "Unique property 1"),
+            new PropertyPair("uniqueProperty2", "Unique property 2"));
+    }
+
+    @Test
+    public void shouldAdaptObjectTypesMetadata() throws IOException {
+        final JsonNode payload = new ObjectMapper().readTree(
+            "[{\"name\":\"Object1\",\"label\":\"Object1 Label\"},{\"name\":\"Object2\",\"label\":\"Object2 Label\"}]");
+
+        final Map<String, List<PropertyPair>> adapted = adapter.apply(NOT_USED,
+            MetaDataBuilder.on(CONTEXT).withAttribute("scope", "object_types").withPayload(payload).build());
+
+        assertThat(adapted).containsKey("sObjectName");
+
+        final List<PropertyPair> values = adapted.get("sObjectName");
+
+        assertThat(values).containsOnly(new PropertyPair("Object1", "Object1 Label"),
+            new PropertyPair("Object2", "Object2 Label"));
+    }
+}


### PR DESCRIPTION
This adds `/api/v1/action/properties` endpoint for dynamic action
properties similar to the one for validating connection/parameters.

It also adds `MetadataAdapter` abstraction to deal with differences
between different Camel Metadata extension.

Implements support for Salesforce.

First PR for review, I would like to add tests.