### PR TITLE
chore(metadata): Adds endpoint for data shapes

### DIFF
--- a/src/main/java/io/syndesis/verifier/v1/ActionPropertiesEndpoint.java
+++ b/src/main/java/io/syndesis/verifier/v1/ActionPropertiesEndpoint.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.verifier.v1;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.Consumes;
@@ -25,6 +26,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import io.syndesis.verifier.v1.metadata.MetadataAdapter;
+import io.syndesis.verifier.v1.metadata.PropertyPair;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.MetaDataExtension;
@@ -46,12 +48,12 @@ public class ActionPropertiesEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{id}")
-    public Object properties(@PathParam("id") final String connectorId, final Map<String, Object> properties)
-        throws Exception {
+    public Map<String, List<PropertyPair>> properties(@PathParam("id") final String connectorId,
+        final Map<String, Object> properties) throws Exception {
         final MetadataAdapter adapter = adapters.get(connectorId + "-adapter");
 
         if (adapter == null) {
-            throw null;
+            throw new IllegalStateException("Unable to fild adapter for:" + connectorId);
         }
 
         final CamelContext camel = camelContext();

--- a/src/main/java/io/syndesis/verifier/v1/ActionShapesEndpoint.java
+++ b/src/main/java/io/syndesis/verifier/v1/ActionShapesEndpoint.java
@@ -15,7 +15,6 @@
  */
 package io.syndesis.verifier.v1;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.Consumes;
@@ -25,28 +24,30 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+
 import io.syndesis.verifier.v1.metadata.MetadataAdapter;
-import io.syndesis.verifier.v1.metadata.PropertyPair;
+import io.syndesis.verifier.v1.metadata.MetadataAdapter.SchemaUse;
 
 import org.springframework.stereotype.Component;
 
 @Component
-@Path("/action/properties")
-public class ActionPropertiesEndpoint extends MetadataEndpoint<Map<String, List<PropertyPair>>> {
+@Path("/action/shapes")
+public class ActionShapesEndpoint extends MetadataEndpoint<Map<MetadataAdapter.SchemaUse, ObjectSchema>> {
 
-    public ActionPropertiesEndpoint(final Map<String, MetadataAdapter> adapters) {
+    public ActionShapesEndpoint(final Map<String, MetadataAdapter> adapters) {
         super(adapters);
     }
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{id}")
-    public Map<String, List<PropertyPair>> properties(@PathParam("id") final String connectorId,
+    @Path("/{connectorId}")
+    public Map<SchemaUse, ObjectSchema> shape(@PathParam("connectorId") final String connectorId,
         final Map<String, Object> properties) throws Exception {
         final MetadataAdapter adapter = adapterFor(connectorId);
 
-        return fetchMetadata(connectorId, properties, adapter::adaptForProperties);
+        return fetchMetadata(connectorId, properties, adapter::adaptForSchema);
     }
 
 }

--- a/src/main/java/io/syndesis/verifier/v1/MetadataEndpoint.java
+++ b/src/main/java/io/syndesis/verifier/v1/MetadataEndpoint.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.verifier.v1;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import io.syndesis.verifier.v1.metadata.MetadataAdapter;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.MetaDataExtension;
+import org.apache.camel.component.extension.MetaDataExtension.MetaData;
+import org.apache.camel.impl.DefaultCamelContext;
+
+abstract class MetadataEndpoint<T> {
+    private final Map<String, MetadataAdapter> adapters;
+
+    /* default */ MetadataEndpoint(final Map<String, MetadataAdapter> adapters) {
+        this.adapters = adapters;
+    }
+
+    /* default */ final MetadataAdapter adapterFor(final String connectorId) {
+        return Optional.ofNullable(adapters.get(connectorId + "-adapter"))
+            .orElseThrow(() -> new IllegalStateException("Unable to fild adapter for:" + connectorId));
+    }
+
+    /* default */ DefaultCamelContext camelContext() {
+        return new DefaultCamelContext();
+    }
+
+    /* default */ final T fetchMetadata(final String connectorId, final Map<String, Object> properties,
+        final BiFunction<Map<String, Object>, MetaData, T> adapterMethod) {
+        try {
+            final CamelContext camel = camelContext();
+            camel.start();
+
+            try {
+                final MetaDataExtension metadataExtension = camel.getComponent(connectorId, true, false)
+                    .getExtension(MetaDataExtension.class).orElseThrow(() -> new IllegalArgumentException(
+                        "No Metadata extension present for connector: " + connectorId));
+
+                final MetaData metaData = metadataExtension.meta(properties)
+                    .orElseThrow(() -> new IllegalArgumentException("No Metadata returned by the metadata extension"));
+
+                return adapterMethod.apply(properties, metaData);
+            } finally {
+                camel.stop();
+            }
+        } catch (final Exception e) {
+            throw new IllegalStateException("Unable to fetch and process metadata", e);
+        }
+    }
+}

--- a/src/main/java/io/syndesis/verifier/v1/metadata/MetadataAdapter.java
+++ b/src/main/java/io/syndesis/verifier/v1/metadata/MetadataAdapter.java
@@ -2,21 +2,48 @@ package io.syndesis.verifier.v1.metadata;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
+
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
 
 import org.apache.camel.component.extension.MetaDataExtension;
 import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 
 /**
- * Converting metadata to applicable properties is specific to each connector,
- * this adapter converts Camel {@link MetaDataExtension.MetaData} to a Map keyed
- * by action property name with a list of {@link PropertyPair} values that are
- * applicable to for that property. {@link #apply(Map, MetaData)} method will
- * receive all properties that client specified and the retrieved
- * {@link MetaDataExtension.MetaData} from the appropriate Camel
- * {@link MetaDataExtension}.
+ * Converting metadata from Camel components to applicable properties or
+ * generating ObjectSchema from Metadata is specific to each connector. This
+ * adapter bridges Camel {@link MetaDataExtension} Component specific
+ * implementations to common Syndesis data model.
  */
-@FunctionalInterface
-public interface MetadataAdapter extends BiFunction<Map<String, Object>, MetaData, Map<String, List<PropertyPair>>> {
-    // inherits apply(MetaData) from Function
+public interface MetadataAdapter {
+
+    enum SchemaUse {
+        INPUT, OUTPUT
+    }
+
+    /**
+     * Converts Camel {@link MetaDataExtension.MetaData} to a Map keyed by
+     * action property name with a list of {@link PropertyPair} values that are
+     * applicable to for that property. Method will receive all properties that
+     * client specified and the retrieved {@link MetaDataExtension.MetaData}
+     * from the appropriate Camel {@link MetaDataExtension}.
+     *
+     * @param properties properties specified on the endpoint
+     * @param metadata the retrieved metadata
+     * @return map keyed by action property of all pairs that can be used as
+     *         values of that property
+     */
+    Map<String, List<PropertyPair>> adaptForProperties(Map<String, Object> properties, MetaData metadata);
+
+    /**
+     * Converts Camel {@link MetaDataExtension.MetaData} to a map of
+     * {@link ObjectSchema}'s keyed by the use of the schema. Method will
+     * receive all properties that client specified and the retrieved
+     * {@link MetaDataExtension.MetaData} from the appropriate Camel
+     * {@link MetaDataExtension}.
+     *
+     * @param properties properties specified on the endpoint
+     * @param metadata the retrieved metadata
+     * @return map keyed by the use of the schema
+     */
+    Map<SchemaUse, ObjectSchema> adaptForSchema(Map<String, Object> properties, MetaData metadata);
 }

--- a/src/test/java/io/syndesis/verifier/v1/ActionShapesEndpointTest.java
+++ b/src/test/java/io/syndesis/verifier/v1/ActionShapesEndpointTest.java
@@ -15,27 +15,27 @@
  */
 package io.syndesis.verifier.v1;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
-import io.syndesis.verifier.v1.metadata.PropertyPair;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+
+import io.syndesis.verifier.v1.metadata.MetadataAdapter;
+import io.syndesis.verifier.v1.metadata.MetadataAdapter.SchemaUse;
 
 import org.apache.camel.impl.DefaultCamelContext;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ActionPropertiesEndpointTest {
-
+public class ActionShapesEndpointTest {
     private static final Map<String, String> PAYLOAD = Collections.singletonMap("this", "is playload");
 
-    private static final Map<String, List<PropertyPair>> PROPERTIES = Collections.singletonMap("property",
-        Arrays.asList(new PropertyPair("value1", "First Value"), new PropertyPair("value2", "Second Value")));
+    private static final Map<MetadataAdapter.SchemaUse, ObjectSchema> SCHEMAS = new HashMap<>();
 
-    private final ActionPropertiesEndpoint endpoint = new ActionPropertiesEndpoint(
-        Collections.singletonMap("petstore-adapter", new PetstoreAdapter(PAYLOAD, PROPERTIES, null))) {
+    private final ActionShapesEndpoint endpoint = new ActionShapesEndpoint(
+        Collections.singletonMap("petstore-adapter", new PetstoreAdapter(PAYLOAD, null, SCHEMAS))) {
         @Override
         protected DefaultCamelContext camelContext() {
             final DefaultCamelContext camelContext = new DefaultCamelContext();
@@ -46,9 +46,9 @@ public class ActionPropertiesEndpointTest {
     };
 
     @Test
-    public void shouldProvideActionShapesBasedOnMetadata() throws Exception {
-        final Map<String, List<PropertyPair>> properties = endpoint.properties("petstore", Collections.emptyMap());
+    public void shouldProvideActionPropertiesBasedOnMetadata() throws Exception {
+        final Map<SchemaUse, ObjectSchema> shapes = endpoint.shape("petstore", Collections.emptyMap());
 
-        assertThat(properties).isSameAs(PROPERTIES);
+        assertThat(shapes).isSameAs(SCHEMAS);
     }
 }

--- a/src/test/java/io/syndesis/verifier/v1/PetstoreAdapter.java
+++ b/src/test/java/io/syndesis/verifier/v1/PetstoreAdapter.java
@@ -1,0 +1,51 @@
+package io.syndesis.verifier.v1;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+
+import io.syndesis.verifier.v1.metadata.MetadataAdapter;
+import io.syndesis.verifier.v1.metadata.PropertyPair;
+
+import org.apache.camel.component.extension.MetaDataExtension.MetaData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PetstoreAdapter implements MetadataAdapter {
+
+    Map<SchemaUse, ObjectSchema> adaptedSchema;
+
+    private final Map<String, List<PropertyPair>> adaptedProperties;
+
+    private final Map<String, String> expectedPayload;
+
+    public PetstoreAdapter(final Map<String, String> expectedPayload,
+        final Map<String, List<PropertyPair>> adaptedProperties, final Map<SchemaUse, ObjectSchema> adaptedSchema) {
+        this.adaptedProperties = adaptedProperties;
+        this.expectedPayload = expectedPayload;
+        this.adaptedSchema = adaptedSchema;
+    }
+
+    @Override
+    public Map<String, List<PropertyPair>> adaptForProperties(final Map<String, Object> properties,
+        final MetaData metadata) {
+        @SuppressWarnings("unchecked")
+        final Map<String, String> payload = metadata.getPayload(Map.class);
+
+        assertThat(payload).isSameAs(expectedPayload);
+
+        return adaptedProperties;
+    }
+
+    @Override
+    public Map<SchemaUse, ObjectSchema> adaptForSchema(final Map<String, Object> properties, final MetaData metadata) {
+        @SuppressWarnings("unchecked")
+        final Map<String, String> payload = metadata.getPayload(Map.class);
+
+        assertThat(payload).isSameAs(expectedPayload);
+
+        return adaptedSchema;
+    }
+
+}

--- a/src/test/java/io/syndesis/verifier/v1/PetstoreComponent.java
+++ b/src/test/java/io/syndesis/verifier/v1/PetstoreComponent.java
@@ -1,0 +1,23 @@
+package io.syndesis.verifier.v1;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.component.extension.MetaDataExtension;
+import org.apache.camel.component.extension.metadata.MetaDataBuilder;
+import org.apache.camel.impl.DefaultComponent;
+
+public class PetstoreComponent extends DefaultComponent {
+
+    public PetstoreComponent(final Object payload) {
+        registerExtension((MetaDataExtension) parameters -> Optional
+            .of(MetaDataBuilder.on(getCamelContext()).withPayload(payload).build()));
+    }
+
+    @Override
+    protected Endpoint createEndpoint(final String uri, final String remaining, final Map<String, Object> parameters)
+        throws Exception {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
This is the first iteration on the data shapes endpoint that returns
JSON Schema of input and output shapes. As it stands it does not take
into the account the action itself, which currently stands to reason if
the action properties that denote what data is requested (name of the
stored procedure or Salesforce object type) is all that is required to
determine the shapes of data.
For Salesforce this is only partially true, as action will be needed
to distinguish from actions that operate on single object and actions
that operate on multiple objects (such as querying data).