### PR TITLE
chore: upgrade Camel to 2.20.0.fuse-000093

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,20 @@
     </repository>
   </repositories>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jboss-ea</id>
+      <name>JBoss Early-access repository</name>
+      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -93,7 +107,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-    <camel.version>2.20.0.fuse-000091</camel.version>
+    <camel.version>2.20.0.fuse-000093</camel.version>
     <swagger.version>1.5.12</swagger.version>
     <resteasy-spring-boot-starter.version>2.3.0-RELEASE</resteasy-spring-boot-starter.version>
     <jackson.version>2.8.7</jackson.version>


### PR DESCRIPTION
This upgrades to the latest Fuse early access build of Camel. This
should keep in line with the connectors project Camel version, see
syndesisio/connectors#61