### PR TITLE
fix(metadata): Better `null` handling

### DIFF
--- a/src/main/java/io/syndesis/verifier/v1/MetadataEndpoint.java
+++ b/src/main/java/io/syndesis/verifier/v1/MetadataEndpoint.java
@@ -16,7 +16,9 @@
 package io.syndesis.verifier.v1;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.syndesis.verifier.v1.metadata.MetadataAdapter;
 import io.syndesis.verifier.v1.metadata.SyndesisMetadata;
@@ -51,7 +53,10 @@ class MetadataEndpoint {
                     .getExtension(MetaDataExtension.class).orElseThrow(() -> new IllegalArgumentException(
                         "No Metadata extension present for connector: " + connectorId));
 
-                final MetaData metaData = metadataExtension.meta(properties)
+                final Map<String, Object> propertiesForMetadataExtension = properties.entrySet().stream()
+                    .filter(e -> e.getValue() != null).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+                final MetaData metaData = metadataExtension.meta(propertiesForMetadataExtension)
                     .orElseThrow(() -> new IllegalArgumentException("No Metadata returned by the metadata extension"));
 
                 return adapter.adapt(properties, metaData);

--- a/src/main/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapter.java
+++ b/src/main/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapter.java
@@ -60,7 +60,7 @@ public final class SalesforceMetadataAdapter implements MetadataAdapter<ObjectSc
                 .map(SalesforceMetadataAdapter::createFieldPairPropertyFromSchemaEntry).collect(Collectors.toList()));
         }
 
-        if (isPresent(properties, SalesforceEndpointConfig.SOBJECT_NAME)) {
+        if (isPresentAndNonNull(properties, SalesforceEndpointConfig.SOBJECT_NAME)) {
             final String objectName = (String) properties.get(SalesforceEndpointConfig.SOBJECT_NAME);
             final ObjectSchema inputOutputSchema = inputOutputSchemaFor(schemasToConsider, objectName);
 


### PR DESCRIPTION
Verifier has no knowledge of the properties required for a Syndesis
action. So `syndesis-rest` sends `null` values for properties action
requires but the user has not specified yet. This is not helpful for
Camel metadata extension, only as a hint to the `MetadataAdapter`s to
set those action properties if requested.

Also SalesforceMetadataAdapter should not fetch schema/data shape for
unspecified (`null`) Salesforce object names.