### PR TITLE
fix: add JsonSchema $schema preamble

### DIFF
--- a/src/main/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapter.java
+++ b/src/main/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapter.java
@@ -70,6 +70,12 @@ public final class SalesforceMetadataAdapter implements MetadataAdapter<ObjectSc
         return new SyndesisMetadata<>(enrichedProperties, null, null);
     }
 
+    static ObjectSchema adaptSchema(final ObjectSchema schema) {
+        schema.set$schema(JsonUtils.SCHEMA4);
+
+        return schema;
+    }
+
     static ObjectSchema convertSalesforceGlobalObjectJsonToSchema(final JsonNode payload) {
         final Set<Object> allSchemas = new HashSet<>();
 
@@ -102,7 +108,7 @@ public final class SalesforceMetadataAdapter implements MetadataAdapter<ObjectSc
     static ObjectSchema inputOutputSchemaFor(final Set<ObjectSchema> schemasToConsider, final String objectName) {
         for (final ObjectSchema schema : schemasToConsider) {
             if (schema.getId().contains(":" + objectName)) {
-                return schema;
+                return adaptSchema(schema);
             }
         }
 

--- a/src/test/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapterTest.java
+++ b/src/test/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapterTest.java
@@ -99,6 +99,7 @@ public class SalesforceMetadataAdapterTest {
         assertThat(metadata.inputSchema).isSameAs(metadata.outputSchema);
         final Object oneOf = payload.getOneOf().iterator().next();
         assertThat(metadata.inputSchema).isSameAs(oneOf);
+        assertThat(metadata.inputSchema.get$schema()).isEqualTo(JsonUtils.SCHEMA4);
     }
 
     @Test


### PR DESCRIPTION
This adds the missing $schema preamble property, the JSON schema
returned by Camel Salesforce Metadata extension already contains it and
we should keep it to help with versioning.

Fixes #27