### PR TITLE
chore: add ExceptionMapper to handle unhandeled Excepions

### DIFF
--- a/src/main/java/io/syndesis/verifier/Application.java
+++ b/src/main/java/io/syndesis/verifier/Application.java
@@ -15,8 +15,12 @@
  */
 package io.syndesis.verifier;
 
+import javax.servlet.Filter;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
 
 /**
  * @author roland
@@ -27,5 +31,17 @@ public class Application {
 
     public static void main(final String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    /**
+     * A filter used capture the request body
+     */
+    @Bean
+    public static Filter requestLoggingFilter() {
+        final CommonsRequestLoggingFilter loggingFilter = new CommonsRequestLoggingFilter();
+        loggingFilter.setIncludePayload(true);
+        loggingFilter.setMaxPayloadLength(512);
+
+        return loggingFilter;
     }
 }

--- a/src/main/java/io/syndesis/verifier/VerifierExceptionMapper.java
+++ b/src/main/java/io/syndesis/verifier/VerifierExceptionMapper.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.verifier;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.StringJoiner;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.WebUtils;
+
+@Component
+@Provider
+public class VerifierExceptionMapper implements ExceptionMapper<Throwable> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VerifierExceptionMapper.class);
+
+    public static class Error {
+        public final String developerMsg;
+
+        public final Integer errorCode;
+
+        public final String userMsg;
+
+        public Error(final Integer errorCode, final String userMsg, final String developerMsg) {
+            this.errorCode = errorCode;
+            this.userMsg = userMsg;
+            this.developerMsg = developerMsg;
+        }
+
+    }
+
+    @Override
+    public Response toResponse(final Throwable exception) {
+        // the proxy @Context would provide would not let us access the wrapped
+        // request
+        final HttpServletRequest request = ResteasyProviderFactory.getContextData(HttpServletRequest.class);
+
+        LOG.error("Exception while handling request: {} {}", request.getMethod(), request.getRequestURI(), exception);
+        if (LOG.isDebugEnabled()) {
+            final ContentCachingRequestWrapper requestCache = WebUtils.getNativeRequest(request,
+                ContentCachingRequestWrapper.class);
+
+            final Enumeration<String> headers = request.getHeaderNames();
+            final StringJoiner headersJoined = new StringJoiner("\n");
+            while (headers.hasMoreElements()) {
+                final String header = headers.nextElement();
+                headersJoined.add(header + ": " + String.join("|", Collections.list(request.getHeaders(header))));
+            }
+            LOG.debug("Headers: \n{}", headersJoined.toString());
+            LOG.debug("Request content: \n{}", new String(requestCache.getContentAsByteArray()));
+        }
+
+        final Error error = new Error(500, rootCauseMessage(exception), exception.getMessage());
+
+        return Response.serverError().entity(error).build();
+    }
+
+    private String rootCauseMessage(final Throwable exception) {
+        Throwable rootCause = exception;
+        while (rootCause.getCause() != null) {
+            rootCause = rootCause.getCause();
+        }
+
+        return rootCause.getMessage();
+
+    }
+
+}


### PR DESCRIPTION
This adds an ExceptionMapper to log the exception and return a JSON
response similar to the responses that the Syndesis REST provides.

User message is set to the message of the root exception with the
hypothesis that this exception's message is the the most appropriate.

There is an option to log the request details if the logging level for
`io.syndesis.verifier` is set to DEBUG.

Fixes #43