### PR TITLE
refactor: upgrade to Camel 2.20.0, few Maven bits

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xmx512m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dmaven.artifact.threads=8

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-    <camel.version>2.20.0.fuse-000106</camel.version>
+    <camel.version>2.20.0</camel.version>
     <swagger.version>1.5.12</swagger.version>
     <resteasy-spring-boot-starter.version>2.3.0-RELEASE</resteasy-spring-boot-starter.version>
     <jackson.version>2.8.7</jackson.version>
@@ -88,34 +88,6 @@
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
     </repository>
   </distributionManagement>
-
-  <repositories>
-    <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
 
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Upgrades Camel to 2.20.0 (from Fuse EA) and removes the Fuse EA
repository. Also adds Maven configuration intended to speed up the
build (GC configuration, 8 parallel threads for downloads).